### PR TITLE
Fix template list header

### DIFF
--- a/src/components/TemplateList.tsx
+++ b/src/components/TemplateList.tsx
@@ -38,7 +38,7 @@ export default function TemplateList() {
         onClick={() => { setEditing(null); setShowEditor(true); }}>+ 新建模板</button>
       <table className="w-full">
         <thead><tr>
-          <th>名称</th><th>版本</th><th>描述</th><th>操作</th>
+          <th>名称</th><th>版本</th><th>操作</th>
         </tr></thead>
         <tbody>
           {templates.map(t => (


### PR DESCRIPTION
## Summary
- remove unused description column from TemplateList header

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'babel__core' et al.)*

------
https://chatgpt.com/codex/tasks/task_e_683fb615651c832c95ce3bf20c20f5b5